### PR TITLE
DeskClock: fix crash when trying to view world cities

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,4 +30,6 @@ LOCAL_AAPT_FLAGS += --extra-packages android.support.v7.appcompat
 LOCAL_AAPT_FLAGS += --extra-packages android.support.v7.gridlayout
 LOCAL_AAPT_FLAGS += --extra-packages com.android.datetimepicker
 
+LOCAL_PROGUARD_FLAG_FILES := proguard.flags
+
 include $(BUILD_PACKAGE)

--- a/proguard.flags
+++ b/proguard.flags
@@ -1,0 +1,1 @@
+-keep class android.support.v7.widget.SearchView { *; }


### PR DESCRIPTION
Add proguard.flags and keep class android.support.v7.widget.SearchView

fixes:
SupportMenuInflater: Cannot instantiate class: android.support.v7.widget.SearchView
SupportMenuInflater: java.lang.NoSuchMethodException: <init> [class android.content.Context]
AndroidRuntime: java.lang.NullPointerException:
Attempt to invoke virtual method 'void android.support.v7.widget.SearchView.setImeOptions(int)' on a null object reference

Change-Id: Iaa260193d48ac086cf54232b433b9dcf7b8ba361
